### PR TITLE
Add Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,46 @@
+# Global Instructions
+
+## Architecture Documentation
+
+When architectural context is needed, do not guess. Instead, use your GitHub tools to explore the
+`SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io` repository. Start by listing
+the `docs/` directory, then read only the .md files relevant to the current task.
+
+## Docs
+
+Always document your work. When the output is code, write clear docstrings for each function. If it
+is not obvious where to document your work, create a new .md file.
+
+## Tests
+
+Whenever possible, write test cases to validate your work. Do not hesitate to write unit tests. If
+you need to write a larger integration test or GitHub workflow, ask for user input first.
+
+## Git & Version Control
+
+Never run `git add`, `git stage`, `git commit`, `git push`, or any equivalent (including GitHub MCP
+`push_files` / `create_or_update_file` to the repo) without **explicit user approval**. Prepare
+changes in the working tree, summarize what is ready, and wait for the user to review before any
+commit is created.
+
+---
+
+# PG Atlas Dashboard — Project-Specific Instructions
+
+## Tooling
+
+...
+
+## Project Layout
+
+...
+
+## Code Style
+
+...
+
+## Keeping These Instructions Current
+
+After completing a todo list for a session, append any new conventions, decisions, or patterns that
+would help future sessions collaborate smoothly. Remove anything that was superseded. This file is
+the hand-off document between sessions.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,6 @@ repos:
         stages: [commit-msg]
         args: [feat, fix, perf, deps, chore, refactor, test, build, ci, docs, style, revert]
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
-    hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
-
   - repo: local
     hooks:
       - id: eslint


### PR DESCRIPTION
- Provide a scaffold for Copilot instructions, meant to be expanded by the dashboard lead.
- Remove `ruff` pre-commit hook — it's a Python linter/formatter and is not relevant here.

I also noticed that pre-commit hooks are not enforced through CI. It's a good idea to add that for consistency. The `pre-commit.ci` check [shows as green](https://results.pre-commit.ci/run/github/1174633488/1773755526.5LMmwOzXQp6ZqDTW74DGPQ), but it looks like it's not actually doing much yet.

The readme currently says:

```md
### Install pre-commit hooks (optional)

If the repo uses [pre-commit](https://pre-commit.com):
```

which I find confusing. I didn't make further changes because it's your decision @KoxyG.