### PR TITLE
chore: upgrade CI dependencies, pin pnpm version, and remove API prox…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 9
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          cache: 'pnpm'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org/"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pg-atlas",
   "private": true,
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -5,21 +5,16 @@
  * this module (not from `@pg-atlas/data-sdk` directly). Loading this
  * file applies the `setConfig` call exactly once, on first hook use.
  *
- * Local (dev + preview): baseUrl defaults to `/api`, server-side proxied by
- *   Vite (`server.proxy` / `preview.proxy` in vite.config.ts) so the browser
- *   never makes a cross-origin request and CORS is a non-issue.
- *
- * Deployed production: requests go to `/api` relative to the serving origin.
- *   This requires a server-side reverse proxy routing /api/* to api.pgatlas.xyz
- *   (e.g. nginx, CDN rewrite rule, or a DO App Platform service). Until that
- *   proxy exists, set VITE_API_BASE_URL=https://api.pgatlas.xyz at build time
- *   AND ensure api.pgatlas.xyz sends CORS headers for the pgatlas.xyz origin.
- *   See BACKEND_GAPS.md for tracking.
+ * The client connects directly to the backend API.
+ * By default it points to the SDK's built-in URL (e.g. `https://api.pgatlas.xyz`).
+ * We rely on the backend enforcing CORS so that any origin can fetch data.
  */
 import { client } from "@pg-atlas/data-sdk";
 
-const baseUrl = import.meta.env.VITE_API_BASE_URL ?? "/api";
+const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
-client.setConfig({ baseUrl });
+if (baseUrl) {
+  client.setConfig({ baseUrl });
+}
 
 export { client };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,34 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const API_TARGET = process.env.VITE_API_BASE_URL ?? 'https://api.pgatlas.xyz'
-
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  server: {
-    proxy: {
-      // Dev-only: forward /api/* to the backend so browser requests don't
-      // trip CORS on localhost. The frontend uses /api as its baseUrl in
-      // dev; in prod it points directly at the backend.
-      '/api': {
-        target: API_TARGET,
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
-      },
-    },
-  },
-  preview: {
-    proxy: {
-      // Mirror the dev proxy for `pnpm preview` so CORS is not an issue
-      // when testing the production build locally.
-      '/api': {
-        target: API_TARGET,
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
-      },
-    },
-  },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
### Description
This PR integrates the final adjustments to the data fetching architecture.

### Key Changes
**API Client & Proxy Cleanup**
- **Removed Vite API Proxies:** Removed `server.proxy` and `preview.proxy` configurations from `vite.config.ts`. Now that the backend enforces proper CORS handling natively, the frontend can fetch directly in all environments without relying on the Vite dev server routing logic.
- **Simplified SDK Client:** Removed the `/api` development fallback in `client.ts`. The client now always fetches directly from the built-in target URL, or from the `VITE_API_BASE_URL` environment variable if overridden.
- **Round Data Integration Updates:** Updated data reconstruction scripts and mapped `liveApiMock` data properly to our internal components.

**Tooling & CI Upgrades**
- **Pinned pnpm:** Added the `packageManager` field to `package.json` to hardcode `pnpm@10.33.0`.
- **Modernized CI Pipeline:** Updated `.github/workflows/ci.yml` to rely on the pinned packageManager field via `pnpm/action-setup@v5`. Upgraded node environments to Node 24 (`actions/setup-node@v6`) and checkout actions to (`actions/checkout@v6`) to prevent runtime deprecation warnings.