### PR TITLE
data(rounds): link to all 17 2026q2 proposals

### DIFF
--- a/src/data/rounds/2025q3.yaml
+++ b/src/data/rounds/2025q3.yaml
@@ -3,48 +3,48 @@ year: 2025
 quarter: 3
 voting_closed: 2025-07-14
 projects:
-  - canonical_id: 
+  - canonical_id:
     name: "Flutter Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "iOS Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "Java Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "OpenGrants"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:python_stellar_sdk
     name: "Python Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:scout
     name: "Scout"
     proposal_pr_url: https://github.com/stellar/stellar-docs/pull/1
     tansu_proposal_url: https://tansu.io/proposals/1
     project_page_url: https://scout.com
-  - canonical_id: 
+  - canonical_id:
     name: "Stellar hardware wallet integration"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url: daoip-5:scf:project:xlm.sh
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:stellar_light
     name: "Stellar Light"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:stellar_php_sdk
     name: "Stellar PHP SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:

--- a/src/data/rounds/2025q4.yaml
+++ b/src/data/rounds/2025q4.yaml
@@ -3,53 +3,53 @@ year: 2025
 quarter: 4
 voting_closed: 2025-10-18
 projects:
-  - canonical_id: 
+  - canonical_id: daoip-5:scf:project:beans_app
     name: ".NET SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "Flutter Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "iOS Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "Java Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "OpenGrants"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:python_stellar_sdk
     name: "Python Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:scout
     name: "Scout"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id: daoip-5:scf:project:xlm.sh
     name: "Stellar hardware wallet integration"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:stellar_light
     name: "Stellar Light"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:stellar_php_sdk
     name: "Stellar PHP SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:

--- a/src/data/rounds/2026q1.yaml
+++ b/src/data/rounds/2026q1.yaml
@@ -5,61 +5,61 @@ voting_closed: 2026-01-25
 projects:
   - canonical_id: daoip-5:scf:project:scout
     name: "Scout"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id: daoip-5:scf:project:xlm.sh
     name: "Stellar hardware wallet integration"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "Java Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:python_stellar_sdk
     name: "Python Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:flutter_wallet_sdk
     name: "Flutter Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "iOS Stellar SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:stellar_php_sdk
     name: "Stellar PHP SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id: daoip-5:scf:project:beans_app
     name: ".NET SDK"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "OpenGrants"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:stellar_light
     name: "Stellar Light"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
   - canonical_id: daoip-5:scf:project:stellarchain.io
     name: "Stellarchain.io"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
-  - canonical_id: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:
+  - canonical_id:
     name: "Scaffold Stellar"
-    proposal_pr_url: 
-    tansu_proposal_url: 
-    project_page_url: 
+    proposal_pr_url:
+    tansu_proposal_url:
+    project_page_url:

--- a/src/data/rounds/2026q2.yaml
+++ b/src/data/rounds/2026q2.yaml
@@ -33,3 +33,75 @@ projects:
     proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/46
     tansu_proposal_url:
     project_page_url:
+
+  - canonical_id: daoip-5:scf:project:solidity_contracts_on_soroban
+    name: "Hyperledger Solang"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/50
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:xlm.sh
+    name: "Stellar Hardware Wallet Support"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/52
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:xlm.sh
+    name: "Java Stellar SDK"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/54
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:python_stellar_sdk
+    name: "Python Stellar SDK"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/56
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:soroban_security_portal
+    name: "Soroban Security Portal"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/59
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:stellarchain.io
+    name: "StellarChain"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/61
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id:
+    name: "Scaffold Stellar"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/63
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id:
+    name: "Stellar Registry"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/65
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:scout
+    name: "Scout"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/67
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:beans_app
+    name: ".NET SDK"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/68
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id: daoip-5:scf:project:stellar_light
+    name: "Stellar Light"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/76
+    tansu_proposal_url:
+    project_page_url:
+
+  - canonical_id:
+    name: "OpenGrants"
+    proposal_pr_url: https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/pull/79
+    tansu_proposal_url:
+    project_page_url:


### PR DESCRIPTION
This PR makes the project list on the 2026q2 round page complete.

It now links to all proposal PRs. I've added project canonical_ids based on main repo linkages, and have backfilled any omissions for previous rounds as well.

Any proposing projects that do not have a canonical_id filled, have repos that have not been linked to any DAOIP-5 project yet. Manually checked them all.