### PR TITLE
feat: sync table pagination and search state with URL search params across projects, repos, contributors, and gitlog routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "material-react-table": "^3.2.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1

--- a/src/pages/Contributors/components/ContributorsTable.tsx
+++ b/src/pages/Contributors/components/ContributorsTable.tsx
@@ -1,34 +1,34 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   MaterialReactTable,
   useMaterialReactTable,
   type MRT_ColumnDef,
   type MRT_PaginationState,
+  type MRT_Updater,
 } from "material-react-table";
 import type { ContributorSummary } from "@pg-atlas/data-sdk";
 import { useContributorsListSuspense } from "../../../lib/api/queries/contributors";
-
-interface ContributorsTableProps {
-  search: string;
-}
+import { contributorsIndexRoute } from "../../../routes/contributors/index";
 
 /**
- * Paginated contributor table backed by `listContributors`. Search is
- * controlled by the parent so the input can debounce independently of
- * the table's own pagination state.
+ * Paginated contributor table backed by `listContributors`.
+ * Search and pagination state are synchronized with the URL.
  */
-export default function ContributorsTable({ search }: ContributorsTableProps) {
-  const navigate = useNavigate();
-  const [pagination, setPagination] = useState<MRT_PaginationState>({
-    pageIndex: 0,
-    pageSize: 20,
-  });
+export default function ContributorsTable() {
+  const genericNavigate = useNavigate();
+  const searchParams = contributorsIndexRoute.useSearch();
+  const navigate = contributorsIndexRoute.useNavigate();
+
+  const pagination: MRT_PaginationState = {
+    pageIndex: searchParams.pageIndex ?? 0,
+    pageSize: searchParams.pageSize ?? 20,
+  };
 
   const { data } = useContributorsListSuspense({
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
-    search: search || null,
+    search: searchParams.search || null,
   });
 
   const contributors = data?.items ?? [];
@@ -65,7 +65,16 @@ export default function ContributorsTable({ search }: ContributorsTableProps) {
     data: contributors,
     manualPagination: true,
     rowCount,
-    onPaginationChange: setPagination,
+    onPaginationChange: (updater: MRT_Updater<MRT_PaginationState>) => {
+      const next = typeof updater === "function" ? updater(pagination) : updater;
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          pageIndex: next.pageIndex,
+          pageSize: next.pageSize,
+        }),
+      });
+    },
     state: { pagination },
     initialState: { density: "compact" },
     enableColumnActions: false,
@@ -74,7 +83,7 @@ export default function ContributorsTable({ search }: ContributorsTableProps) {
     enableSorting: false,
     muiTableBodyRowProps: ({ row }) => ({
       onClick: () =>
-        navigate({
+        genericNavigate({
           to: "/contributors/$id",
           params: { id: String(row.original.id) },
         }),

--- a/src/pages/Contributors/index.tsx
+++ b/src/pages/Contributors/index.tsx
@@ -7,21 +7,37 @@ import {
   ContributorsTableFallback,
   ContributorsTableSkeleton,
 } from "./components/ContributorsTableFallbacks";
+import { contributorsIndexRoute } from "../../routes/contributors/index";
 
 const SEARCH_DEBOUNCE_MS = 300;
 
 export default function Contributors() {
-  const [inputValue, setInputValue] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const search = contributorsIndexRoute.useSearch();
+  const navigate = contributorsIndexRoute.useNavigate();
+  const [inputValue, setInputValue] = useState(search.search ?? "");
+  const [prevSearch, setPrevSearch] = useState(search.search);
 
-  // Debounce typing so we don't fire a request on every keystroke. A
-  // short delay keeps the UI responsive while avoiding API thrash.
+  // Sync input value when URL change (e.g. browser back button) during render phase
+  if (search.search !== prevSearch) {
+    setPrevSearch(search.search);
+    setInputValue(search.search ?? "");
+  }
+
+  // Debounce typing so we don't fire a request on every keystroke.
   useEffect(() => {
     const handle = window.setTimeout(() => {
-      setDebouncedSearch(inputValue.trim());
+      if (inputValue !== (search.search ?? "")) {
+        navigate({
+          search: (prev) => ({
+            ...prev,
+            search: inputValue.trim() || undefined,
+            pageIndex: 0,
+          }),
+        });
+      }
     }, SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(handle);
-  }, [inputValue]);
+  }, [inputValue, navigate, search.search]);
 
   return (
     <div>
@@ -53,7 +69,7 @@ export default function Contributors() {
       <MuiThemeProvider>
         <ErrorBoundary fallback={<ContributorsTableFallback />}>
           <Suspense fallback={<ContributorsTableSkeleton />}>
-            <ContributorsTable search={debouncedSearch} />
+            <ContributorsTable />
           </Suspense>
         </ErrorBoundary>
       </MuiThemeProvider>

--- a/src/pages/GitlogArtifacts/components/ArtifactsTable.tsx
+++ b/src/pages/GitlogArtifacts/components/ArtifactsTable.tsx
@@ -1,35 +1,35 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   MaterialReactTable,
   useMaterialReactTable,
   type MRT_ColumnDef,
   type MRT_PaginationState,
+  type MRT_Updater,
 } from "material-react-table";
 import type { GitLogArtifactSummary, SubmissionStatus } from "@pg-atlas/data-sdk";
 import { useGitlogArtifactsListSuspense } from "../../../lib/api/queries/gitlog";
 import { StatusBadge } from "./StatusBadge";
-
-interface ArtifactsTableProps {
-  repo: string;
-}
+import { gitlogIndexRoute } from "../../../routes/gitlog/index";
 
 /**
- * Paginated table of gitlog processing attempts. `repo` filters by
- * repo canonical_id (exact match) — controlled by the parent so the
- * filter input can debounce independently.
+ * Paginated table of gitlog processing attempts.
+ * Search and pagination state are synchronized with the URL.
  */
-export default function ArtifactsTable({ repo }: ArtifactsTableProps) {
-  const navigate = useNavigate();
-  const [pagination, setPagination] = useState<MRT_PaginationState>({
-    pageIndex: 0,
-    pageSize: 20,
-  });
+export default function ArtifactsTable() {
+  const genericNavigate = useNavigate();
+  const searchValues = gitlogIndexRoute.useSearch();
+  const navigate = gitlogIndexRoute.useNavigate();
+
+  const pagination: MRT_PaginationState = {
+    pageIndex: searchValues.pageIndex ?? 0,
+    pageSize: searchValues.pageSize ?? 20,
+  };
 
   const { data } = useGitlogArtifactsListSuspense({
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
-    repo: repo || null,
+    repo: searchValues.repo || null,
   });
 
   const items = data?.items ?? [];
@@ -81,7 +81,16 @@ export default function ArtifactsTable({ repo }: ArtifactsTableProps) {
     data: items,
     manualPagination: true,
     rowCount,
-    onPaginationChange: setPagination,
+    onPaginationChange: (updater: MRT_Updater<MRT_PaginationState>) => {
+      const next = typeof updater === "function" ? updater(pagination) : updater;
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          pageIndex: next.pageIndex,
+          pageSize: next.pageSize,
+        }),
+      });
+    },
     state: { pagination },
     initialState: { density: "compact" },
     enableColumnActions: false,
@@ -90,7 +99,7 @@ export default function ArtifactsTable({ repo }: ArtifactsTableProps) {
     enableSorting: false,
     muiTableBodyRowProps: ({ row }) => ({
       onClick: () =>
-        navigate({
+        genericNavigate({
           to: "/gitlog/$artifactId",
           params: { artifactId: String(row.original.id) },
         }),

--- a/src/pages/GitlogArtifacts/index.tsx
+++ b/src/pages/GitlogArtifacts/index.tsx
@@ -7,6 +7,7 @@ import {
   ArtifactsTableFallback,
   ArtifactsTableSkeleton,
 } from "./components/ArtifactsTableFallbacks";
+import { gitlogIndexRoute } from "../../routes/gitlog/index";
 
 const FILTER_DEBOUNCE_MS = 300;
 
@@ -16,15 +17,32 @@ const FILTER_DEBOUNCE_MS = 300;
  * `listGitlogArtifacts`; supports repo-canonical-id filtering.
  */
 export default function GitlogArtifacts() {
-  const [inputValue, setInputValue] = useState("");
-  const [debouncedRepo, setDebouncedRepo] = useState("");
+  const search = gitlogIndexRoute.useSearch();
+  const navigate = gitlogIndexRoute.useNavigate();
+  const [inputValue, setInputValue] = useState(search.repo ?? "");
+  const [prevRepo, setPrevRepo] = useState(search.repo);
 
+  // Sync input value when URL change (e.g. browser back button) during render phase
+  if (search.repo !== prevRepo) {
+    setPrevRepo(search.repo);
+    setInputValue(search.repo ?? "");
+  }
+
+  // Debounce typing so we don't fire a request on every keystroke.
   useEffect(() => {
     const handle = window.setTimeout(() => {
-      setDebouncedRepo(inputValue.trim());
+      if (inputValue !== (search.repo ?? "")) {
+        navigate({
+          search: (prev) => ({
+            ...prev,
+            repo: inputValue.trim() || undefined,
+            pageIndex: 0,
+          }),
+        });
+      }
     }, FILTER_DEBOUNCE_MS);
     return () => window.clearTimeout(handle);
-  }, [inputValue]);
+  }, [inputValue, navigate, search.repo]);
 
   return (
     <div>
@@ -57,7 +75,7 @@ export default function GitlogArtifacts() {
       <MuiThemeProvider>
         <ErrorBoundary fallback={<ArtifactsTableFallback />}>
           <Suspense fallback={<ArtifactsTableSkeleton />}>
-            <ArtifactsTable repo={debouncedRepo} />
+            <ArtifactsTable />
           </Suspense>
         </ErrorBoundary>
       </MuiThemeProvider>

--- a/src/pages/Projects/index.tsx
+++ b/src/pages/Projects/index.tsx
@@ -1,22 +1,27 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   MaterialReactTable,
   useMaterialReactTable,
   type MRT_ColumnDef,
   type MRT_PaginationState,
+  type MRT_Updater,
 } from "material-react-table";
 import MuiThemeProvider from "../../components/atoms/MuiThemeProvider";
 import { useProjectsListSuspense } from "../../lib/api/queries/projects";
 import type { ProjectSummary } from "@pg-atlas/data-sdk";
+import { projectsIndexRoute } from "../../routes/projects/index";
 
 function ProjectsTable() {
-  const navigate = useNavigate();
-  const [pagination, setPagination] = useState<MRT_PaginationState>({
-    pageIndex: 0,
-    pageSize: 20,
-  });
-  const [globalFilter, setGlobalFilter] = useState("");
+  const genericNavigate = useNavigate();
+  const search = projectsIndexRoute.useSearch();
+  const navigate = projectsIndexRoute.useNavigate();
+
+  const pagination: MRT_PaginationState = {
+    pageIndex: search.pageIndex ?? 0,
+    pageSize: search.pageSize ?? 20,
+  };
+  const globalFilter = search.search ?? "";
 
   const { data } = useProjectsListSuspense({
     limit: pagination.pageSize,
@@ -76,18 +81,31 @@ function ProjectsTable() {
     manualPagination: true,
     manualFiltering: true,
     rowCount,
-    onPaginationChange: setPagination,
-    onGlobalFilterChange: (updater) => {
-      const next =
-        typeof updater === "function" ? updater(globalFilter) : updater;
-      setGlobalFilter(next ?? "");
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    onPaginationChange: (updater: MRT_Updater<MRT_PaginationState>) => {
+      const next = typeof updater === "function" ? updater(pagination) : updater;
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          pageIndex: next.pageIndex,
+          pageSize: next.pageSize,
+        }),
+      });
+    },
+    onGlobalFilterChange: (updater: MRT_Updater<string>) => {
+      const next = typeof updater === "function" ? updater(globalFilter) : updater;
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          search: next || undefined,
+          pageIndex: 0,
+        }),
+      });
     },
     state: { pagination, globalFilter },
     initialState: { density: "compact" },
     muiTableBodyRowProps: ({ row }) => ({
       onClick: () =>
-        navigate({
+        genericNavigate({
           to: "/projects/$canonicalId",
           params: { canonicalId: row.original.canonical_id },
         }),

--- a/src/pages/Repos/index.tsx
+++ b/src/pages/Repos/index.tsx
@@ -1,22 +1,27 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   MaterialReactTable,
   useMaterialReactTable,
   type MRT_ColumnDef,
   type MRT_PaginationState,
+  type MRT_Updater,
 } from "material-react-table";
 import MuiThemeProvider from "../../components/atoms/MuiThemeProvider";
 import { useReposListSuspense } from "../../lib/api/queries/repos";
 import type { RepoSummary } from "@pg-atlas/data-sdk";
+import { reposIndexRoute } from "../../routes/repos/index";
 
 function ReposTable() {
-  const navigate = useNavigate();
-  const [pagination, setPagination] = useState<MRT_PaginationState>({
-    pageIndex: 0,
-    pageSize: 20,
-  });
-  const [globalFilter, setGlobalFilter] = useState("");
+  const genericNavigate = useNavigate();
+  const search = reposIndexRoute.useSearch();
+  const navigate = reposIndexRoute.useNavigate();
+
+  const pagination: MRT_PaginationState = {
+    pageIndex: search.pageIndex ?? 0,
+    pageSize: search.pageSize ?? 20,
+  };
+  const globalFilter = search.search ?? "";
 
   const { data } = useReposListSuspense({
     limit: pagination.pageSize,
@@ -88,18 +93,31 @@ function ReposTable() {
     manualPagination: true,
     manualFiltering: true,
     rowCount,
-    onPaginationChange: setPagination,
-    onGlobalFilterChange: (updater) => {
-      const next =
-        typeof updater === "function" ? updater(globalFilter) : updater;
-      setGlobalFilter(next ?? "");
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    onPaginationChange: (updater: MRT_Updater<MRT_PaginationState>) => {
+      const next = typeof updater === "function" ? updater(pagination) : updater;
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          pageIndex: next.pageIndex,
+          pageSize: next.pageSize,
+        }),
+      });
+    },
+    onGlobalFilterChange: (updater: MRT_Updater<string>) => {
+      const next = typeof updater === "function" ? updater(globalFilter) : updater;
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          search: next || undefined,
+          pageIndex: 0,
+        }),
+      });
     },
     state: { pagination, globalFilter },
     initialState: { density: "compact" },
     muiTableBodyRowProps: ({ row }) => ({
       onClick: () =>
-        navigate({
+        genericNavigate({
           to: "/repos/$canonicalId",
           params: { canonicalId: row.original.canonical_id },
         }),

--- a/src/routes/contributors/index.tsx
+++ b/src/routes/contributors/index.tsx
@@ -1,6 +1,13 @@
 import { lazy } from "react";
 import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { rootRoute } from "../__root";
+
+const contributorsSearchSchema = z.object({
+  pageIndex: z.number().catch(0).optional(),
+  pageSize: z.number().catch(20).optional(),
+  search: z.string().catch("").optional(),
+});
 
 const Contributors = lazy(() => import("../../pages/Contributors"));
 
@@ -8,4 +15,5 @@ export const contributorsIndexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/contributors",
   component: Contributors,
+  validateSearch: (search) => contributorsSearchSchema.parse(search),
 });

--- a/src/routes/gitlog/index.tsx
+++ b/src/routes/gitlog/index.tsx
@@ -1,6 +1,13 @@
 import { lazy } from "react";
 import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { rootRoute } from "../__root";
+
+const gitlogSearchSchema = z.object({
+  pageIndex: z.number().catch(0).optional(),
+  pageSize: z.number().catch(20).optional(),
+  repo: z.string().catch("").optional(),
+});
 
 const GitlogArtifacts = lazy(() => import("../../pages/GitlogArtifacts"));
 
@@ -8,4 +15,5 @@ export const gitlogIndexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/gitlog",
   component: GitlogArtifacts,
+  validateSearch: (search) => gitlogSearchSchema.parse(search),
 });

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -1,6 +1,13 @@
 import { lazy } from "react";
 import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { rootRoute } from "../__root";
+
+const projectsSearchSchema = z.object({
+  pageIndex: z.number().catch(0).optional(),
+  pageSize: z.number().catch(20).optional(),
+  search: z.string().catch("").optional(),
+});
 
 const Projects = lazy(() => import("../../pages/Projects"));
 
@@ -8,4 +15,5 @@ export const projectsIndexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/projects",
   component: Projects,
+  validateSearch: (search) => projectsSearchSchema.parse(search),
 });

--- a/src/routes/repos/index.tsx
+++ b/src/routes/repos/index.tsx
@@ -1,6 +1,13 @@
 import { lazy } from "react";
 import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { rootRoute } from "../__root";
+
+const reposSearchSchema = z.object({
+  pageIndex: z.number().catch(0).optional(),
+  pageSize: z.number().catch(20).optional(),
+  search: z.string().catch("").optional(),
+});
 
 const Repos = lazy(() => import("../../pages/Repos"));
 
@@ -8,4 +15,5 @@ export const reposIndexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/repos",
   component: Repos,
+  validateSearch: (search) => reposSearchSchema.parse(search),
 });


### PR DESCRIPTION
This PR addresses the issue where search queries and pagination positions were lost when navigating between list pages (Projects, Repos, Contributors, Gitlog) and their respective detail pages. By synchronizing the UI state with the URL's search parameters, we ensure that the user's context is preserved across browser navigation (Back/Forward).

Additionally, this PR identifies and fixes a bug in the Gitlog search where the page index was not correctly reset when a new filter was applied.

## Key Changes
- **URL Synchronization**: Migrated local component state (`useState`) to **TanStack Router Search Parameters** for all major search pages.
- **Type-Safe Validation**: Integrated `zod` to provide robust, typed validation and default values for URL parameters.
- **Improved UX**:
  - Implemented debounced search synchronization that updates the URL.
  - Added a **render-phase state adjustment** for search inputs to ensure they stay in sync with URL changes (e.g., via the browser's Back button) without triggering cascading renders.
- **Bug Fix**: Fixed a pagination reset issue in the `GitlogArtifacts` page where applying a repository filter would keep the user on their previous (potentially empty) page index.
- **Code Quality**: Verified all changes with `pnpm lint` and `pnpm build` (TSC).

## Technical Details
- **New Dependency**: `zod` for schema validation.
- **Persistence Scope**:
  - **Projects**: Search filter and pagination index.
  - **Repos**: Search filter and pagination index.
  - **Contributors**: Search filter and pagination index.
  - **Gitlog**: Repository ID filter and pagination index.

