### PR TITLE
feat: add accessibility titles to truncated UI elements and enable external graph traversal by default

### DIFF
--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -274,7 +274,10 @@ export default function DashboardLayout() {
             >
               <Menu className="h-5 w-5" />
             </button>
-            <h1 className="text-lg font-bold text-surface-dark truncate dark:text-white">
+            <h1
+              className="text-lg font-bold text-surface-dark truncate dark:text-white"
+              title={currentNav.name}
+            >
               {currentNav.name}
             </h1>
             <button

--- a/src/components/molecules/SubGraphExplorer.tsx
+++ b/src/components/molecules/SubGraphExplorer.tsx
@@ -116,7 +116,7 @@ export default function SubGraphExplorer({
             nodeLabel,
             result.data,
             dir,
-            { includeExternal: false },
+            { includeExternal: true },
           );
         } else {
           newElements = projectNeighborsToElements(

--- a/src/lib/graph/styles.ts
+++ b/src/lib/graph/styles.ts
@@ -11,7 +11,7 @@ import type { Stylesheet } from "cytoscape";
 const NODE_COLORS: Record<string, string> = {
   project: "#914cff",
   repo: "#3b82f6",
-  "external-repo": "#64748b",
+  "external-repo": "#facc15",
 };
 
 const graphStyles: Stylesheet[] = [
@@ -62,6 +62,7 @@ const graphStyles: Stylesheet[] = [
       "border-style": "dashed",
       width: 24,
       height: 24,
+      color: "#facc15",
     } as unknown as Record<string, string | number>,
   },
 

--- a/src/lib/graph/transforms.ts
+++ b/src/lib/graph/transforms.ts
@@ -66,7 +66,7 @@ export function repoNeighborsToElements(
   direction: TraversalDirection,
   opts: { includeExternal?: boolean } = {},
 ): ElementDefinition[] {
-  const { includeExternal = false } = opts;
+  const { includeExternal = true } = opts;
 
   const elements: ElementDefinition[] = [];
 

--- a/src/pages/Home/components/CurrentRoundCard.tsx
+++ b/src/pages/Home/components/CurrentRoundCard.tsx
@@ -37,7 +37,10 @@ function StatTile({
           />
         </div>
       </div>
-      <p className="mt-1.5 truncate text-lg font-bold text-surface-dark dark:text-white sm:text-xl">
+      <p
+        className="mt-1.5 truncate text-lg font-bold text-surface-dark dark:text-white sm:text-xl"
+        title={value.toString()}
+      >
         {value}
       </p>
     </div>

--- a/src/pages/Home/components/DataTransparencyPanel.tsx
+++ b/src/pages/Home/components/DataTransparencyPanel.tsx
@@ -128,7 +128,10 @@ export default function DataTransparencyPanel() {
           {isLoading ? (
             <Skeleton className="h-3 w-32" />
           ) : (
-            <span className="truncate font-mono text-surface-dark/70 dark:text-white/70">
+            <span
+              className="truncate font-mono text-surface-dark/70 dark:text-white/70"
+              title={lastUpdated ?? "unknown"}
+            >
               {lastUpdated ?? "unknown"}
             </span>
           )}
@@ -151,7 +154,10 @@ export default function DataTransparencyPanel() {
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
-                      <span className="truncate text-xs font-medium text-surface-dark dark:text-white">
+                      <span
+                        className="truncate text-xs font-medium text-surface-dark dark:text-white"
+                        title={s.label}
+                      >
                         {s.label}
                       </span>
                       <KindBadge kind={s.kind} />

--- a/src/pages/Home/components/MetricsGrid.tsx
+++ b/src/pages/Home/components/MetricsGrid.tsx
@@ -35,7 +35,10 @@ export default function MetricsGrid() {
             </div>
           </div>
           <div className="flex flex-col gap-y-2">
-            <p className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white">
+            <p
+              className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white"
+              title={`${metadata.active_projects.toLocaleString()} / ${metadata.total_projects.toLocaleString()}`}
+            >
               {metadata.active_projects.toLocaleString()}
               <span className="mx-2 text-surface-dark/20 dark:text-white/20 font-light">
                 /
@@ -62,7 +65,10 @@ export default function MetricsGrid() {
             </div>
           </div>
           <div className="flex flex-col gap-y-2">
-            <p className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white">
+            <p
+              className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white"
+              title={`${metadata.total_repos.toLocaleString()} | ${metadata.total_external_repos.toLocaleString()}`}
+            >
               {metadata.total_repos.toLocaleString()}
               <span className="mx-2 text-surface-dark/20 dark:text-white/20 font-light">
                 |
@@ -96,7 +102,10 @@ export default function MetricsGrid() {
             </div>
           </div>
           <div className="flex flex-col gap-y-1 sm:gap-y-2">
-            <p className="mt-1 sm:mt-2 truncate text-lg sm:text-3xl font-bold text-surface-dark dark:text-white">
+            <p
+              className="mt-1 sm:mt-2 truncate text-lg sm:text-3xl font-bold text-surface-dark dark:text-white"
+              title={metadata.total_dependency_edges.toLocaleString()}
+            >
               {metadata.total_dependency_edges.toLocaleString()}
             </p>
             <p className="hidden sm:block mt-1 text-sm text-surface-dark/35 dark:text-white/50">
@@ -120,7 +129,10 @@ export default function MetricsGrid() {
             </div>
           </div>
           <div className="flex flex-col gap-y-1 sm:gap-y-2">
-            <p className="mt-1 sm:mt-2 truncate text-lg sm:text-3xl font-bold text-surface-dark dark:text-white">
+            <p
+              className="mt-1 sm:mt-2 truncate text-lg sm:text-3xl font-bold text-surface-dark dark:text-white"
+              title={metadata.total_contributor_edges.toLocaleString()}
+            >
               {metadata.total_contributor_edges.toLocaleString()}
             </p>
             <p className="hidden sm:block mt-1 text-sm text-surface-dark/35 dark:text-white/50">

--- a/src/pages/ProjectDetail/components/DependenciesPanel.tsx
+++ b/src/pages/ProjectDetail/components/DependenciesPanel.tsx
@@ -71,7 +71,9 @@ function DepList({
                 params={{ canonicalId: dep.project.canonical_id }}
                 className="flex items-center justify-between rounded-lg px-3 py-2 text-base text-surface-dark transition-colors hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
               >
-                <span className="truncate">{dep.project.display_name}</span>
+                <span className="truncate" title={dep.project.display_name}>
+                  {dep.project.display_name}
+                </span>
                 <span className="ml-2 shrink-0 text-sm text-surface-dark/50 dark:text-white/40">
                   {dep.edge_count} edge{dep.edge_count === 1 ? "" : "s"}
                 </span>

--- a/src/pages/ProjectDetail/components/MetricsPanel.tsx
+++ b/src/pages/ProjectDetail/components/MetricsPanel.tsx
@@ -70,7 +70,16 @@ export function MetricsPanel({ project }: { project: ProjectDetailResponse }) {
                   />
                 </div>
               </div>
-              <p className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white">
+              <p
+                className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white"
+                title={
+                  m.value != null
+                    ? m.format === "decimal"
+                      ? m.value.toFixed(2)
+                      : Math.round(m.value).toLocaleString()
+                    : "—"
+                }
+              >
                 {m.value != null
                   ? m.format === "decimal"
                     ? m.value.toFixed(2)

--- a/src/pages/ProjectDetail/components/ReposPanel.tsx
+++ b/src/pages/ProjectDetail/components/ReposPanel.tsx
@@ -38,11 +38,14 @@ export function ReposPanel({ repos }: { repos: RepoSummary[] }) {
                   className="h-4 w-4 shrink-0 text-surface-dark/30 dark:text-white/30"
                   aria-hidden="true"
                 />
-                <span className="truncate text-sm font-medium text-surface-dark dark:text-white">
+                <span
+                  className="truncate text-sm font-medium text-surface-dark dark:text-white"
+                  title={r.display_name}
+                >
                   {r.display_name}
                 </span>
                 <span className="hidden shrink-0 text-xs text-surface-dark/40 dark:text-white/30 sm:inline">
-                  {r.latest_version ? `v${r.latest_version}` : r.visibility}
+                  {r.latest_version ? r.latest_version : r.visibility}
                 </span>
               </div>
               <div className="flex shrink-0 items-center gap-3">

--- a/src/pages/RepoDetail/components/DependenciesPanel.tsx
+++ b/src/pages/RepoDetail/components/DependenciesPanel.tsx
@@ -105,8 +105,10 @@ function DepItem({
 }) {
   const content = (
     <>
-      <span className="truncate">{dep.display_name}</span>
-      <div className="ml-2 flex shrink-0 items-center gap-2">
+      <span className="truncate" title={dep.display_name}>
+        {dep.display_name}
+      </span>
+      <div className="ml-2 flex min-w-0 shrink-0 items-center gap-2">
         {dep.confidence && (
           <span
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
@@ -119,7 +121,10 @@ function DepItem({
           </span>
         )}
         {dep.version_range && (
-          <span className="text-sm font-mono text-surface-dark/40 dark:text-white/30">
+          <span
+            className="max-w-[120px] truncate text-sm font-mono text-surface-dark/40 dark:text-white/30"
+            title={dep.version_range}
+          >
             {dep.version_range}
           </span>
         )}

--- a/src/pages/RepoDetail/components/MetricsPanel.tsx
+++ b/src/pages/RepoDetail/components/MetricsPanel.tsx
@@ -83,7 +83,16 @@ export function MetricsPanel({ repo }: { repo: RepoDetailResponse }) {
                   />
                 </div>
               </div>
-              <p className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white">
+              <p
+                className="mt-1.5 sm:mt-2 truncate text-2xl sm:text-3xl font-bold text-surface-dark dark:text-white"
+                title={
+                  m.value != null
+                    ? m.format === "decimal"
+                      ? m.value.toFixed(2)
+                      : Math.round(m.value).toLocaleString()
+                    : "—"
+                }
+              >
                 {m.value != null
                   ? m.format === "decimal"
                     ? m.value.toFixed(2)
@@ -104,7 +113,7 @@ export function MetricsPanel({ repo }: { repo: RepoDetailResponse }) {
         </span>
         {repo.latest_version && (
           <span className="rounded-full border border-gray-200 px-3 py-1.5 text-sm font-mono text-surface-dark/70 dark:border-white/15 dark:text-white/60">
-            v{repo.latest_version}
+            {repo.latest_version}
           </span>
         )}
         {repo.repo_url && (


### PR DESCRIPTION
closes #25 